### PR TITLE
Optional integrate

### DIFF
--- a/src/sorcha/ephemeris/pixel_dict.py
+++ b/src/sorcha/ephemeris/pixel_dict.py
@@ -116,9 +116,15 @@ class PixelDict:
 
         self.pixel_dict = defaultdict(list)
 
-        self.rho_hat_m_dict = self.get_all_object_unit_vectors(self.r_obs_m, self.tm, use_integrate=use_integrate)
-        self.rho_hat_0_dict = self.get_all_object_unit_vectors(self.r_obs_0, self.t0, use_integrate=use_integrate)
-        self.rho_hat_p_dict = self.get_all_object_unit_vectors(self.r_obs_p, self.tp, use_integrate=use_integrate)
+        self.rho_hat_m_dict = self.get_all_object_unit_vectors(
+            self.r_obs_m, self.tm, use_integrate=use_integrate
+        )
+        self.rho_hat_0_dict = self.get_all_object_unit_vectors(
+            self.r_obs_0, self.t0, use_integrate=use_integrate
+        )
+        self.rho_hat_p_dict = self.get_all_object_unit_vectors(
+            self.r_obs_p, self.tp, use_integrate=use_integrate
+        )
 
         self.compute_pixel_traversed()
 
@@ -314,7 +320,9 @@ class PixelDict:
 
                     self.tm = self.t0 - self.picket_interval
                     self.r_obs_m = self.get_observatory_position(self.tm)
-                    self.rho_hat_m_dict = self.get_all_object_unit_vectors(self.r_obs_m, self.tm, use_integrate=use_integrate)
+                    self.rho_hat_m_dict = self.get_all_object_unit_vectors(
+                        self.r_obs_m, self.tm, use_integrate=use_integrate
+                    )
 
                 else:
                     # shift later
@@ -328,7 +336,9 @@ class PixelDict:
 
                     self.tp = self.t0 + self.picket_interval
                     self.r_obs_p = self.get_observatory_position(self.tp)
-                    self.rho_hat_p_dict = self.get_all_object_unit_vectors(self.r_obs_p, self.tp, use_integrate=use_integrate)
+                    self.rho_hat_p_dict = self.get_all_object_unit_vectors(
+                        self.r_obs_p, self.tp, use_integrate=use_integrate
+                    )
 
             else:
                 # Need to compute three new sets
@@ -337,15 +347,21 @@ class PixelDict:
                 # This is repeated code
                 self.t0 += n * self.picket_interval
                 self.r_obs_0 = self.get_observatory_position(self.t0)
-                self.rho_hat_0_dict = self.get_all_object_unit_vectors(self.r_obs_0, self.t0, use_integrate=use_integrate)
+                self.rho_hat_0_dict = self.get_all_object_unit_vectors(
+                    self.r_obs_0, self.t0, use_integrate=use_integrate
+                )
 
                 self.tp = self.t0 + self.picket_interval
                 self.r_obs_p = self.get_observatory_position(self.tp)
-                self.rho_hat_p_dict = self.get_all_object_unit_vectors(self.r_obs_p, self.tp, use_integrate=use_integrate)
+                self.rho_hat_p_dict = self.get_all_object_unit_vectors(
+                    self.r_obs_p, self.tp, use_integrate=use_integrate
+                )
 
                 self.tm = self.t0 - self.picket_interval
                 self.r_obs_m = self.get_observatory_position(self.tm)
-                self.rho_hat_m_dict = self.get_all_object_unit_vectors(self.r_obs_m, self.tm, use_integrate=use_integrate)
+                self.rho_hat_m_dict = self.get_all_object_unit_vectors(
+                    self.r_obs_m, self.tm, use_integrate=use_integrate
+                )
 
             self.compute_pixel_traversed()
         else:

--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -181,6 +181,7 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
         picket_interval,
         nside,
         n_sub_intervals=n_sub_intervals,
+        use_integrate=use_integrate
     )
     for _, pointing in pointings_df.iterrows():
         mjd_tai = float(pointing["observationMidpointMJD_TAI"])
@@ -190,9 +191,9 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
         # compute a new set
 
         desigs = pixdict.get_designations(
-            pointing["fieldJD_TDB"], pointing["fieldRA_deg"], pointing["fieldDec_deg"], ang_fov
+            pointing["fieldJD_TDB"], pointing["fieldRA_deg"], pointing["fieldDec_deg"], ang_fov, use_integrate=use_integrate
         )
-        unit_vectors = pixdict.interpolate_unit_vectors(desigs, pointing["fieldJD_TDB"])
+        unit_vectors = pixdict.interpolate_unit_vectors(desigs, pointing["fieldJD_TDB"], use_integrate=use_integrate)
         visit_vector = get_vec(pointing, "visit_vector")
         r_obs = get_vec(pointing, "r_obs")
 

--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -113,6 +113,10 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
     nside = 2 ** configs["ar_healpix_order"]
     n_sub_intervals = 101  # configs["n_sub_intervals"]
 
+    use_integrate = False
+    if configs["ar_use_integrate"]:
+        use_integrate = True
+
     ephemeris_csv_filename = None
     if args.output_ephemeris_file and args.outpath:
         ephemeris_csv_filename = os.path.join(args.outpath, args.output_ephemeris_file)
@@ -208,7 +212,7 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
                     _,
                     ephem_geom_params.r_ast,
                     ephem_geom_params.v_ast,
-                ) = integrate_light_time(sim, ex, pointing["fieldJD_TDB"] - ephem.jd_ref, r_obs, lt0=0.01)
+                ) = integrate_light_time(sim, ex, pointing["fieldJD_TDB"] - ephem.jd_ref, r_obs, lt0=0.01, use_integrate=use_integrate)
                 ephem_geom_params.rho_hat = ephem_geom_params.rho / ephem_geom_params.rho_mag
 
                 ang_from_center = 180 / np.pi * np.arccos(np.dot(ephem_geom_params.rho_hat, visit_vector))

--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -181,7 +181,7 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
         picket_interval,
         nside,
         n_sub_intervals=n_sub_intervals,
-        use_integrate=use_integrate
+        use_integrate=use_integrate,
     )
     for _, pointing in pointings_df.iterrows():
         mjd_tai = float(pointing["observationMidpointMJD_TAI"])
@@ -191,9 +191,15 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
         # compute a new set
 
         desigs = pixdict.get_designations(
-            pointing["fieldJD_TDB"], pointing["fieldRA_deg"], pointing["fieldDec_deg"], ang_fov, use_integrate=use_integrate
+            pointing["fieldJD_TDB"],
+            pointing["fieldRA_deg"],
+            pointing["fieldDec_deg"],
+            ang_fov,
+            use_integrate=use_integrate,
         )
-        unit_vectors = pixdict.interpolate_unit_vectors(desigs, pointing["fieldJD_TDB"], use_integrate=use_integrate)
+        unit_vectors = pixdict.interpolate_unit_vectors(
+            desigs, pointing["fieldJD_TDB"], use_integrate=use_integrate
+        )
         visit_vector = get_vec(pointing, "visit_vector")
         r_obs = get_vec(pointing, "r_obs")
 
@@ -213,7 +219,14 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
                     _,
                     ephem_geom_params.r_ast,
                     ephem_geom_params.v_ast,
-                ) = integrate_light_time(sim, ex, pointing["fieldJD_TDB"] - ephem.jd_ref, r_obs, lt0=0.01, use_integrate=use_integrate)
+                ) = integrate_light_time(
+                    sim,
+                    ex,
+                    pointing["fieldJD_TDB"] - ephem.jd_ref,
+                    r_obs,
+                    lt0=0.01,
+                    use_integrate=use_integrate,
+                )
                 ephem_geom_params.rho_hat = ephem_geom_params.rho / ephem_geom_params.rho_mag
 
                 ang_from_center = 180 / np.pi * np.arccos(np.dot(ephem_geom_params.rho_hat, visit_vector))

--- a/src/sorcha/ephemeris/simulation_geometry.py
+++ b/src/sorcha/ephemeris/simulation_geometry.py
@@ -26,7 +26,7 @@ def ecliptic_to_equatorial(v, rot_mat=ECL_TO_EQ_ROTATION_MATRIX):
     return np.dot(v, rot_mat)
 
 
-def integrate_light_time(sim, ex, t, r_obs, lt0=0, iter=3, speed_of_light=SPEED_OF_LIGHT):
+def integrate_light_time(sim, ex, t, r_obs, lt0=0, iter=3, speed_of_light=SPEED_OF_LIGHT, use_integrate=False):
     """
     Performs the light travel time correction between object and observatory iteratively for the object at a given reference time
 
@@ -46,6 +46,8 @@ def integrate_light_time(sim, ex, t, r_obs, lt0=0, iter=3, speed_of_light=SPEED_
         Number of iterations
     speed_of_light: float
         Speed of light for the calculation (default is SPEED_OF_LIGHT constant)
+    use_integrate: boolean
+        Flag to use the integrate method instead of integrate_or_interpolate
     Returns
     -------
     rho: array
@@ -61,7 +63,10 @@ def integrate_light_time(sim, ex, t, r_obs, lt0=0, iter=3, speed_of_light=SPEED_
     """
     lt = lt0
     for i in range(iter):
-        ex.integrate_or_interpolate(t - lt)
+        if use_integrate:
+            sim.integrate(t - lt)
+        else:
+            ex.integrate_or_interpolate(t - lt)
         target = np.array(sim.particles[0].xyz)
         vtarget = np.array(sim.particles[0].vxyz)
         rho = target - r_obs

--- a/src/sorcha/ephemeris/simulation_geometry.py
+++ b/src/sorcha/ephemeris/simulation_geometry.py
@@ -26,7 +26,9 @@ def ecliptic_to_equatorial(v, rot_mat=ECL_TO_EQ_ROTATION_MATRIX):
     return np.dot(v, rot_mat)
 
 
-def integrate_light_time(sim, ex, t, r_obs, lt0=0, iter=3, speed_of_light=SPEED_OF_LIGHT, use_integrate=False):
+def integrate_light_time(
+    sim, ex, t, r_obs, lt0=0, iter=3, speed_of_light=SPEED_OF_LIGHT, use_integrate=False
+):
     """
     Performs the light travel time correction between object and observatory iteratively for the object at a given reference time
 

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -868,9 +868,9 @@ def PPPrintConfigsToLog(configs, cmd_args):
     )
 
     if configs["ar_use_integrate"]:
-        pplogger.info("Assist/rebound integration is ON. Integrate or interpolate will NOT be used.")
+        pplogger.info("ASSIST+REBOUND integration is ON. Integrate or interpolate will NOT be used.")
     else:
-        pplogger.info("Assist/rebound integration is OFF. Integrate or interpolate will be used.")
+        pplogger.info("ASSIST+REBOUND integration is OFF. Integrate or interpolate will be used.")
 
     if configs["trailing_losses_on"]:
         pplogger.info("Computation of trailing losses is switched ON.")

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -747,7 +747,6 @@ def PPConfigFileParser(configfile, survey_name):
             "ERROR: SNR limit and magnitude limit are mutually exclusive. Please delete one or both from config file."
         )
 
-
     try:
         config_dict["ar_use_integrate"] = config.getboolean("EXPERT", "ar_use_integrate", fallback=False)
     except ValueError:
@@ -867,6 +866,11 @@ def PPPrintConfigsToLog(configs, cmd_args):
         "The apparent brightness is calculated using the following phase function model: "
         + configs["phase_function"]
     )
+
+    if configs["ar_use_integrate"]:
+        pplogger.info("Assist/rebound integration is ON. Integrate or interpolate will NOT be used.")
+    else:
+        pplogger.info("Assist/rebound integration is OFF. Integrate or interpolate will be used.")
 
     if configs["trailing_losses_on"]:
         pplogger.info("Computation of trailing losses is switched ON.")

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -747,6 +747,17 @@ def PPConfigFileParser(configfile, survey_name):
             "ERROR: SNR limit and magnitude limit are mutually exclusive. Please delete one or both from config file."
         )
 
+
+    try:
+        config_dict["ar_use_integrate"] = config.getboolean("EXPERT", "ar_use_integrate", fallback=False)
+    except ValueError:
+        pplogger.error(
+            "ERROR: could not parse value for ar_use_integrate as a boolean. Check formatting and try again."
+        )
+        sys.exit(
+            "ERROR: could not parse value for ar_use_integrate as a boolean. Check formatting and try again."
+        )
+
     try:
         config_dict["trailing_losses_on"] = config.getboolean("EXPERT", "trailing_losses_on", fallback=True)
     except ValueError:

--- a/tests/data/test_PPPrintConfigsToLog.txt
+++ b/tests/data/test_PPPrintConfigsToLog.txt
@@ -14,7 +14,7 @@ sorcha.modules.PPConfigParser INFO     The main filter in which H is defined is 
 sorcha.modules.PPConfigParser INFO     The filters included in the post-processing results are r g i z 
 sorcha.modules.PPConfigParser INFO     Thus, the colour indices included in the simulation are g-r i-r z-r 
 sorcha.modules.PPConfigParser INFO     The apparent brightness is calculated using the following phase function model: HG 
-sorcha.modules.PPConfigParser INFO     ASSIST+REBOUND integration is OFF. Integrate or interpolate will be used.
+sorcha.modules.PPConfigParser INFO     ASSIST+REBOUND integration is OFF. Integrate or interpolate will be used. 
 sorcha.modules.PPConfigParser INFO     Computation of trailing losses is switched ON. 
 sorcha.modules.PPConfigParser INFO     Randomization of position and magnitude around uncertainties is switched ON. 
 sorcha.modules.PPConfigParser INFO     Vignetting is switched ON. 

--- a/tests/data/test_PPPrintConfigsToLog.txt
+++ b/tests/data/test_PPPrintConfigsToLog.txt
@@ -14,6 +14,7 @@ sorcha.modules.PPConfigParser INFO     The main filter in which H is defined is 
 sorcha.modules.PPConfigParser INFO     The filters included in the post-processing results are r g i z 
 sorcha.modules.PPConfigParser INFO     Thus, the colour indices included in the simulation are g-r i-r z-r 
 sorcha.modules.PPConfigParser INFO     The apparent brightness is calculated using the following phase function model: HG 
+sorcha.modules.PPConfigParser INFO     ASSIST+REBOUND integration is OFF. Integrate or interpolate will be used.
 sorcha.modules.PPConfigParser INFO     Computation of trailing losses is switched ON. 
 sorcha.modules.PPConfigParser INFO     Randomization of position and magnitude around uncertainties is switched ON. 
 sorcha.modules.PPConfigParser INFO     Vignetting is switched ON. 

--- a/tests/ephemeris/test_ephemeris_generation.py
+++ b/tests/ephemeris/test_ephemeris_generation.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 import os
 import re
+from numpy.testing import assert_almost_equal
 
 from sorcha.utilities.dataUtilitiesForTests import get_test_filepath, get_demo_filepath
 from sorcha.modules.PPConfigParser import PPConfigFileParser
@@ -150,6 +151,21 @@ def test_ephemeris_end2end(single_synthetic_pointing, tmp_path):
 
     for file in files:
         assert not re.match(r".+\.csv", file)
+
+    configs["ar_use_integrate"] = True
+
+    observations_integrate = create_ephemeris(
+        single_synthetic_pointing,
+        filterpointing,
+        args,
+        configs,
+    )
+
+    assert len(observations_integrate) == 10
+
+    assert_almost_equal (observations_integrate["fieldMJD_TAI"].values, observations["fieldMJD_TAI"].values, decimal=6)
+    assert_almost_equal (observations_integrate["RA_deg"].values, observations["RA_deg"].values, decimal=6)
+    assert_almost_equal (observations_integrate["Dec_deg"].values, observations["Dec_deg"].values, decimal=6)
 
 
 def test_ephemeris_writeread_csv(single_synthetic_ephemeris, tmp_path):

--- a/tests/ephemeris/test_ephemeris_generation.py
+++ b/tests/ephemeris/test_ephemeris_generation.py
@@ -163,9 +163,11 @@ def test_ephemeris_end2end(single_synthetic_pointing, tmp_path):
 
     assert len(observations_integrate) == 10
 
-    assert_almost_equal (observations_integrate["fieldMJD_TAI"].values, observations["fieldMJD_TAI"].values, decimal=6)
-    assert_almost_equal (observations_integrate["RA_deg"].values, observations["RA_deg"].values, decimal=6)
-    assert_almost_equal (observations_integrate["Dec_deg"].values, observations["Dec_deg"].values, decimal=6)
+    assert_almost_equal(
+        observations_integrate["fieldMJD_TAI"].values, observations["fieldMJD_TAI"].values, decimal=6
+    )
+    assert_almost_equal(observations_integrate["RA_deg"].values, observations["RA_deg"].values, decimal=6)
+    assert_almost_equal(observations_integrate["Dec_deg"].values, observations["Dec_deg"].values, decimal=6)
 
 
 def test_ephemeris_writeread_csv(single_synthetic_ephemeris, tmp_path):

--- a/tests/sorcha/test_PPConfigParser.py
+++ b/tests/sorcha/test_PPConfigParser.py
@@ -77,6 +77,7 @@ def test_PPConfigFileParser(setup_and_teardown_for_PPConfigFileParser):
         "lc_model": None,
         "randomization_on": True,
         "vignetting_on": True,
+        "ar_use_integrate": False,
     }
 
     assert configs == test_configs
@@ -300,6 +301,7 @@ def test_PPPrintConfigsToLog(tmp_path):
         "lc_model": None,
         "randomization_on": True,
         "vignetting_on": True,
+        "ar_use_integrate": False,
     }
 
     PPPrintConfigsToLog(configs, args)


### PR DESCRIPTION
Fixes # .

Adds a config parameter ar_use_integrate that uses the rebound integrate method instead of assist's integrate_and_interpolate. This is important for accuracy for close approaches and fast movers. 

## Review Checklist for Source Code Changes

- [x] Does pip install still work? 
- [x] Have you written a unit test for any new functions? 
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
